### PR TITLE
Fix bug parsing "12AM" as noon instead of midnight

### DIFF
--- a/numbers/src/main/java/org/dicio/numbers/lang/en/EnglishDateTimeExtractor.kt
+++ b/numbers/src/main/java/org/dicio/numbers/lang/en/EnglishDateTimeExtractor.kt
@@ -120,8 +120,9 @@ class EnglishDateTimeExtractor internal constructor(
             }
         }
 
-        if (pm != null && pm && !DateTimeExtractorUtils.isMomentOfDayPm(time.hour)!!) {
+        if (pm != null && ((pm && !DateTimeExtractorUtils.isMomentOfDayPm(time.hour)!!) || (!pm && time.hour == 12))) {
             // time must be in the afternoon, but time is not already in the afternoon, correct it
+            // alternatively time is midnight and must be parsed as "morning"
             time = time.withHour((time.hour + 12) % DateTimeExtractorUtils.HOURS_IN_DAY)
         }
         return time

--- a/numbers/src/main/java/org/dicio/numbers/lang/it/ItalianDateTimeExtractor.kt
+++ b/numbers/src/main/java/org/dicio/numbers/lang/it/ItalianDateTimeExtractor.kt
@@ -110,14 +110,18 @@ class ItalianDateTimeExtractor internal constructor(
             pm = ts.tryOrSkipDateTimeIgnore(true) {
                 Utils.firstNotNull(
                     dateTimeExtractor::ampm,
-                    { DateTimeExtractorUtils.isMomentOfDayPm(momentOfDay()) }
+                    { momentOfDay()?.let(DateTimeExtractorUtils::isMomentOfDayPm) }
                 )
             }
         }
 
-        if (pm != null && pm && !DateTimeExtractorUtils.isMomentOfDayPm(time.hour)!!) {
-            // time must be in the afternoon, but time is not already in the afternoon, correct it
-            time = time.withHour((time.hour + 12) % DateTimeExtractorUtils.HOURS_IN_DAY)
+        if (time.hour != 0 && pm != null) {
+            // AM/PM should not do anything after 0 (e.g. 0pm or 24 di sera)
+
+            if (pm && !DateTimeExtractorUtils.isMomentOfDayPm(time.hour)) {
+                // time must be in the afternoon, but time is not already, correct it
+                time = time.withHour((time.hour + 12) % DateTimeExtractorUtils.HOURS_IN_DAY)
+            }
         }
         return time
     }

--- a/numbers/src/main/java/org/dicio/numbers/util/DateTimeExtractorUtils.kt
+++ b/numbers/src/main/java/org/dicio/numbers/util/DateTimeExtractorUtils.kt
@@ -207,10 +207,7 @@ class DateTimeExtractorUtils(
         val MONTHS_IN_YEAR: Long = Month.entries.size.toLong() // 12
 
         @JvmStatic
-        fun isMomentOfDayPm(momentOfDay: Int?): Boolean? {
-            if (momentOfDay == null) {
-                return null
-            }
+        fun isMomentOfDayPm(momentOfDay: Int): Boolean {
             return momentOfDay >= 12
         }
     }

--- a/numbers/src/test/java/org/dicio/numbers/lang/en/ExtractDateTimeTest.java
+++ b/numbers/src/test/java/org/dicio/numbers/lang/en/ExtractDateTimeTest.java
@@ -460,8 +460,9 @@ public class ExtractDateTimeTest extends WithTokenizerTestBase {
         assertTimeWithAmpm("18:29:02 and am",                     LocalTime.of(18, 29, 2),  5);
         assertTimeWithAmpm("evening",                             LocalTime.of(21, 0,  0),  1);
         assertTimeWithAmpm("afternoon at four and three and six", LocalTime.of(16, 3,  6),  7);
-        // this turns out wrong, but it is a corner case
-        assertTimeWithAmpm("twenty four in the evening",          LocalTime.of(12, 0,  0),  5);
+        // corner cases:
+        assertTimeWithAmpm("twenty four in the evening",          LocalTime.of(0,  0,  0),  5);
+        assertTimeWithAmpm("12 am",                               LocalTime.of(0,  0,  0),  2);
     }
 
     @Test

--- a/numbers/src/test/java/org/dicio/numbers/lang/it/ExtractDateTimeTest.java
+++ b/numbers/src/test/java/org/dicio/numbers/lang/it/ExtractDateTimeTest.java
@@ -392,15 +392,17 @@ public class ExtractDateTimeTest extends WithTokenizerTestBase {
 
     @Test
     public void testTimeWithAmpm() {
-        assertTimeWithAmpm("11:28.33 pm test",                          LocalTime.of(23, 28, 33), 5);
-        assertTimeWithAmpm("mezzogiorno e mezzo dopo pranzo",           LocalTime.of(12, 30, 0),  5);
-        assertTimeWithAmpm("alle due di notte",                         LocalTime.of(2,  0,  0),  4);
-        assertTimeWithAmpm("le tre e trentotto di pomeriggio",          LocalTime.of(15, 38, 0),  7);
-        assertTimeWithAmpm("18:29:02 e am",                             LocalTime.of(18, 29, 2),  5);
-        assertTimeWithAmpm("sera",                                      LocalTime.of(21, 0,  0),  1);
-        assertTimeWithAmpm("pomeriggio alle quattro e tre e sei",       LocalTime.of(16, 3,  6),  7);
-        // this turns out wrong, but it is a corner case
-        assertTimeWithAmpm("le ventiquattro di sera",                   LocalTime.of(12, 0,  0),  5);
+        assertTimeWithAmpm("11:28.33 pm test",                    LocalTime.of(23, 28, 33), 5);
+        assertTimeWithAmpm("mezzogiorno e mezzo dopo pranzo",     LocalTime.of(12, 30, 0),  5);
+        assertTimeWithAmpm("alle due di notte",                   LocalTime.of(2,  0,  0),  4);
+        assertTimeWithAmpm("le tre e trentotto di pomeriggio",    LocalTime.of(15, 38, 0),  7);
+        assertTimeWithAmpm("18:29:02 e am",                       LocalTime.of(18, 29, 2),  5);
+        assertTimeWithAmpm("sera",                                LocalTime.of(21, 0,  0),  1);
+        assertTimeWithAmpm("pomeriggio alle quattro e tre e sei", LocalTime.of(16, 3,  6),  7);
+        // corner cases:
+        assertTimeWithAmpm("le ventiquattro di sera",             LocalTime.of(0,  0,  0),  5);
+        // this is different than in English on purpose
+        assertTimeWithAmpm("12 am",                               LocalTime.of(12, 0,  0),  2);
     }
 
     @Test

--- a/numbers/src/test/java/org/dicio/numbers/test/DateTimeExtractorUtilsTestBase.java
+++ b/numbers/src/test/java/org/dicio/numbers/test/DateTimeExtractorUtilsTestBase.java
@@ -137,7 +137,5 @@ public abstract class DateTimeExtractorUtilsTestBase extends WithTokenizerTestBa
         assertEquals(Boolean.TRUE, isMomentOfDayPm(12));
         assertEquals(Boolean.TRUE, isMomentOfDayPm(18));
         assertEquals(Boolean.TRUE, isMomentOfDayPm(24));
-        //noinspection ConstantConditions
-        assertNull(isMomentOfDayPm(null));
     }
 }


### PR DESCRIPTION
Expected Behavior: time input "12AM" is parsed internally as `"12:00", pm: false` and then finalized as `"00:00"`

Actual Behavior:  time input "12AM" is parsed internally as `"12:00", pm: false` and then finalized as `"12:00"`

Notes: I appended the check for whether the input is a "12AM" case to the condition handling 12-hour afternoon time not being converted to 24-hour time internally as it requires the same solution